### PR TITLE
Fix: Footer About Challenge link scrolls to correct section (#480)

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
   </section>
 
   <!-- About the Challenge Section -->
-  <section class="about-challenge-section">
+  <section id="about-challenge" class="about-challenge-section">
     <div class="container">
       <div class="about-challenge-header">
         <h2 class="about-challenge-title">About the Challenge</h2>
@@ -291,7 +291,7 @@
           <h3 class="footer-title">Quick Links</h3>
           <ul class="footer-links">
             <li><a href="#projects" class="footer-link">Browse Projects</a></li>
-            <li><a href="#" class="footer-link">About Challenge</a></li>
+            <li><a href="#about-challenge" class="footer-link">About Challenge</a></li>
             <li><a href="contributors.html" class="footer-link">Contributors</a></li>
             <li><a href="https://github.com/ruchikakengal/100_Days_100_webprojects" class="footer-link">GitHub Repository</a></li>
           </ul>


### PR DESCRIPTION
### Description

Fixes the broken footer "About Challenge" link.

### Changes
- Added `id="about-challenge"` to the section.
- Updated footer link to `#about-challenge`.

Closes #480
