### PR TITLE
Fix: auto-scroll on pagination

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -51,6 +51,18 @@ class WebDev100Days {
         if (page && page !== this.currentPage) {
           this.currentPage = page;
           this.renderTable();
+
+           // Scroll headings se start ho
+      setTimeout(() => {
+        const tableHead = document.querySelector("table thead");
+        if (tableHead) {
+          // Agar koi fixed header ya navbar height hai to uska offset nikal lo
+          const headerOffset = 80; // yahan apne header ki actual height set karo
+          const y = tableHead.getBoundingClientRect().top + window.scrollY - headerOffset;
+          window.scrollTo({ top: y, behavior: "smooth" });
+        }
+      }, 50);
+      
         }
       }
     });


### PR DESCRIPTION
📌 Fixed Issue: #555

### Summary
Earlier on clicking on pagination buttons (e.g., Page 2), the new content loads but the page stays at the bottom.  
This PR ensures the page automatically scrolls to the top after pagination navigation, so users can see the updated content immediately.

✅ Changes:
- Added scroll-to-top behavior in pagination click handler

💡 UX Improvement:  
Prevents confusion and ensures a smoother browsing experience.

Please let me know if you have any feedback or want any improvement. Thank you!
